### PR TITLE
Added links and styling to header

### DIFF
--- a/react-portfolio/src/assets/style/App.css
+++ b/react-portfolio/src/assets/style/App.css
@@ -45,11 +45,19 @@ header div ul li {
   margin-top: 5%;
   display: inline-block;
   margin-left: 30px;
+  font-size: 25px;
+  list-style: none;
 }
 
-p {
-  font-size: 25px;
-  color: whitesmoke;
+.link {
+  text-decoration: none;
+  color: rgba(188, 213, 231, 0.63);
+  transition: 2s;
+}
+
+.link:hover {
+  color: white;
+  transition: 0.3s;
 }
 
 .footContain {

--- a/react-portfolio/src/components/Header.js
+++ b/react-portfolio/src/components/Header.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom'
 
 function Header() {
   return (
@@ -6,10 +7,10 @@ function Header() {
       <h1>Todd Dharni</h1>
         <div className='headerContent'>
             <ul>
-              <li><p>About Me</p></li>
-              <li><p>Portfolio</p></li>
-              <li><p>Resume</p></li>
-              <li><p>Contact</p></li>
+              <li><Link className='link' to="/about">About Me</Link></li>
+              <li><Link className='link' to="/portfolio">Portfolio</Link></li>
+              <li><Link className='link' to="/resume">Resume</Link></li>
+              <li><Link className='link' to="/contact">Contact</Link></li>
             </ul>
         </div>
     </header>


### PR DESCRIPTION
With this push the content within the header is now aligned with their associated links, so whenever you click on each of the tabs (`About Me`, `Portfolio`, `Resume`, and `Contact`) it will update the main body of the webpage to display different content between the `Header` and `Footer` of the page.

I also styled the links so that they glow when you hover over them, similar to how I did with the icons within the `Footer` to keep with consistency of design.

Next push will also be small to have the `About Me` be the default for when the page loads.