### PR TITLE
Added portfolio content + styling

### DIFF
--- a/react-portfolio/src/components/Cards.js
+++ b/react-portfolio/src/components/Cards.js
@@ -6,30 +6,185 @@ import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
 import Button from '@mui/material/Button';
 import { Typography } from '@mui/material';
+import Stack from '@mui/material/Stack';
+import Grid from '@mui/material/Grid';
 
+import united from '../assets/images/project-united.jpg';
+import notes from '../assets/images/note-taker.jpg';
+import cabinet from '../assets/images/cabinet-keeper.jpg';
+import password from '../assets/images/password-generator.png';
+import readme from '../assets/images/document-info.png';
 import cat from '../assets/images/bowtie-cat.png';
+import lead from '../assets/images/lead-generation.png';
 
 function MediaCard() {
   return(
-    <Card sx={{ maxWidth: 345, bgcolor: 'lightcyan' }}>
-      <CardMedia 
-        sx={{ height: 194 }}
-        image={cat}
-        title='cat with a bowtie'
-      />
-      <CardContent>
-        <Typography gutterBottom variant='h5' component='div'>
-          Pre-Work Study Guide
-        </Typography>
-        <Typography gutterBottom variant='h5' color='text.secondary'>
-          An application designed to help students study HTML, CSS and JavaScript
-        </Typography>
+    <Grid margin={2} marginLeft={14} marginRight={14}>
+    <Stack spacing={4}  direction={'row'}>
+
+      {/* Project United Card */}
+      <Grid paddingBottom={10}>
+      <Card sx={{ maxWidth: 345, bgcolor: 'lightcyan' }}>
+        <CardMedia 
+          sx={{ height: 194 }}
+          image={united}
+          title='A dark purple background with cream font of text that says Project United'
+        />
+        <CardContent>
+          <Typography gutterBottom variant='h5' component='div'>
+            Project United
+          </Typography>
+          <Typography gutterBottom variant='h5' color='text.secondary'>
+            A community application to help find and support local LGBTQ+ friendly organizations in Utah
+          </Typography>
         </CardContent>
-      <CardActions>
-        <Button size="large" href="https://aegeangrey.github.io/prework-study-guide/" rel='noopener noreferrer' target="_blank">Application</Button>
-        <Button size="large" href="https://github.com/AegeanGrey/prework-study-guide" rel='noopener noreferrer' target="_blank">Github Repository</Button>
-      </CardActions>
-    </Card>
+        <CardActions>
+          <Button size="large" href="https://project-united.herokuapp.com" rel='noopener noreferrer' target="_blank">Application</Button>
+          <Button size="large" href="https://github.com/Childofrainydays/project-united" rel='noopener noreferrer' target="_blank">Github Repository</Button>
+        </CardActions>
+      </Card>
+      </Grid>
+
+      {/* Note Taker Card */}
+      <Grid>
+      <Card sx={{ maxWidth: 345, bgcolor: 'lightcyan' }}>
+        <CardMedia 
+          sx={{ height: 194 }}
+          image={notes}
+          title='A blue background with white font of text that says Note Taker'
+        />
+        <CardContent>
+          <Typography gutterBottom variant='h5' component='div'>
+            Note Taker
+          </Typography>
+          <Typography gutterBottom variant='h5' color='text.secondary'>
+            An all in one place to write, save and retrieve your notes via JavaScript, JSON, and HTTP Requests
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="large" href="https://noteynotes-a2993dbf9bbe.herokuapp.com" rel='noopener noreferrer' target="_blank">Application</Button>
+          <Button size="large" href="https://github.com/AegeanGrey/note-taker" rel='noopener noreferrer' target="_blank">Github Repository</Button>
+        </CardActions>
+      </Card>
+      </Grid>
+
+      {/* Cabinet Keepers Card */}
+      <Grid>
+      <Card sx={{ maxWidth: 345, bgcolor: 'lightcyan' }}>
+        <CardMedia 
+          sx={{ height: 194 }}
+          image={cabinet}
+          title='A white box with a black outline that has a red button bellow it saying Generate Password'
+        />
+        <CardContent>
+          <Typography gutterBottom variant='h5' component='div'>
+            Cabinet Keepers
+          </Typography>
+          <Typography gutterBottom variant='h5' color='text.secondary'>
+            A group effort in aiding college students find recipes based on the ingredients they have in their pantry
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="large" href="https://aegeangrey.github.io/team-waffles/" rel='noopener noreferrer' target="_blank">Application</Button>
+          <Button size="large" href="https://github.com/AegeanGrey/team-waffles" rel='noopener noreferrer' target="_blank">Github Repository</Button>
+        </CardActions>
+      </Card>
+      </Grid>
+
+      {/* Password Generator Card */}
+      <Grid>
+      <Card sx={{ maxWidth: 345, bgcolor: 'lightcyan' }}>
+        <CardMedia 
+          sx={{ height: 194 }}
+          image={password}
+          title='A white box with a black outline that has a red button bellow it saying Generate Password'
+        />
+        <CardContent>
+          <Typography gutterBottom variant='h5' component='div'>
+            Password Generator
+          </Typography>
+          <Typography gutterBottom variant='h5' color='text.secondary'>
+            The most effective and effecient way of creating a new password with the logic of JavaScript
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="large" href="https://aegeangrey.github.io/password-generator/" rel='noopener noreferrer' target="_blank">Application</Button>
+          <Button size="large" href="https://github.com/AegeanGrey/password-generator" rel='noopener noreferrer' target="_blank">Github Repository</Button>
+        </CardActions>
+      </Card>
+      </Grid>
+    </Stack>
+
+    <Stack spacing={3} direction={'row'}>
+      {/* README Card */}
+      <Grid>
+      <Card sx={{ maxWidth: 345, bgcolor: 'lightcyan' }}>
+        <CardMedia 
+          sx={{ height: 194 }}
+          image={readme}
+          title='Sketch of a file with document'
+        />
+        <CardContent>
+          <Typography gutterBottom variant='h5' component='div'>
+            README Generator
+          </Typography>
+          <Typography gutterBottom variant='h5' color='text.secondary'>
+            A faster and reliable way to create brand new README.md files
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="large" href="https://github.com/AegeanGrey/readme-generator" rel='noopener noreferrer' target="_blank">Github Repository</Button>
+        </CardActions>
+      </Card>
+      </Grid>
+
+      {/* Study Guide Card */}
+      <Grid>
+      <Card sx={{ maxWidth: 345, bgcolor: 'lightcyan' }}>
+        <CardMedia 
+          sx={{ height: 194 }}
+          image={cat}
+          title='cat with a bowtie'
+        />
+        <CardContent>
+          <Typography gutterBottom variant='h5' component='div'>
+            Pre-Work Study Guide
+          </Typography>
+          <Typography gutterBottom variant='h5' color='text.secondary'>
+            An application designed to help students study HTML, CSS and JavaScript
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="large" href="https://aegeangrey.github.io/prework-study-guide/" rel='noopener noreferrer' target="_blank">Application</Button>
+          <Button size="large" href="https://github.com/AegeanGrey/prework-study-guide" rel='noopener noreferrer' target="_blank">Github Repository</Button>
+        </CardActions>
+      </Card>
+      </Grid>
+
+      {/* Horiseon Card */}
+      <Grid>
+      <Card sx={{ maxWidth: 345, bgcolor: 'lightcyan' }}>
+        <CardMedia 
+          sx={{ height: 194 }}
+          image={lead}
+          title='Gear being processed into currency'
+        />
+        <CardContent>
+          <Typography gutterBottom variant='h5' component='div'>
+            Horiseon (Sample Webpage)
+          </Typography>
+          <Typography gutterBottom variant='h5' color='text.secondary'>
+            Webpage with descriptive comments describing each semantic HTML element
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="large" href="https://aegeangrey.github.io/horiseon-mock-up/" rel='noopener noreferrer' target="_blank">Application</Button>
+          <Button size="large" href="https://github.com/AegeanGrey/horiseon-mock-up" rel='noopener noreferrer' target="_blank">Github Repository</Button>
+        </CardActions>
+      </Card>
+      </Grid>
+    </Stack>
+  </Grid>
   )
 }
 

--- a/react-portfolio/src/webpages/Contact.js
+++ b/react-portfolio/src/webpages/Contact.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
-import MediaCard from '../components/Cards';
 
 // Page for Contact Informations Structure/Content
 function Contact() {
@@ -9,7 +8,6 @@ function Contact() {
     <div>
       <Header />
       <h3>Contact</h3>
-      <MediaCard />
       <Footer />
     </div>
   )

--- a/react-portfolio/src/webpages/Portfolio.js
+++ b/react-portfolio/src/webpages/Portfolio.js
@@ -1,73 +1,14 @@
 import React from 'react';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
-
-import united from '../assets/images/project-united.jpg';
-import notes from '../assets/images/note-taker.jpg';
-import cabinet from '../assets/images/cabinet-keeper.jpg';
-import password from '../assets/images/password-generator.png';
-import readme from '../assets/images/document-info.png';
-import lead from '../assets/images/lead-generation.png';
+import MediaCard from '../components/Cards'
 
 // Page for my Portfolios Structure/Content
 function Portfolio() {
   return (
     <div>
       <Header />
-        <section>
-          <h3 className="center">Portfolio</h3>
-            <div className="portfolio">
-
-                <article className="card">
-                    <div className="card-header">
-                      <h4>Project United</h4>
-                      <p>A group project in support of LGBTQ+ communities within Utah</p>
-                    </div>
-                  <a href="https://project-united.herokuapp.com" rel='noopener noreferrer' target="_blank"><img src={united} alt="Simple formatted text that says Project United with purple background" /></a>
-                </article>
-
-                <article className="card">
-                    <div className="card-header">
-                        <h4>Note Taker</h4>
-                        <p>Established Routing and HTTP Requests/Responses</p>
-                    </div>
-                    <a href="https://noteynotes-a2993dbf9bbe.herokuapp.com" rel='noopener noreferrer' target="_blank"><img src={notes} alt="Simple formatted text that says Note Taker with a baby blue background" /></a>
-                </article>
-
-                <article class="card">
-                    <div class="card-header">
-                        <h4>Cabinet Keeper</h4>
-                        <p>Displays recipes based on user listed ingredients</p>
-                    </div>
-                    <a href="https://aegeangrey.github.io/team-waffles/" rel='noopener noreferrer' target="_blank"><img src={cabinet} alt="" /></a>
-                </article>
-                
-                <article class="card">
-                    <div class="card-header">
-                        <h4>Password Generator</h4>
-                        <p>Built JavaScript</p>
-                    </div>
-                    <a href="https://aegeangrey.github.io/password-generator/" rel='noopener noreferrer' target="_blank"><img src={password} alt="" /></a>
-                </article>
-
-                <article class="card">
-                    <div class="card-header">
-                        <h4>README Generator</h4>
-                        <p>Creates README File for projects</p>
-                    </div>
-                    <a href="https://github.com/AegeanGrey/readme-generator" rel='noopener noreferrer' target="_blank"><img src={readme} alt="Sketch of a file with document" /></a>
-                </article>
-
-                <article class="card">
-                    <div class="card-header">
-                        <h4>Horiseon</h4>
-                        <p>Provided Semantic HTML</p>
-                    </div>
-                    <a href="https://aegeangrey.github.io/horiseon-mock-up/" rel='noopener noreferrer' target="_blank"><img src={lead} alt="Gear being processed into currency" /></a>
-                </article>
-            
-            </div>
-        </section>
+      <MediaCard />
       <Footer />
     </div>
   )


### PR DESCRIPTION
It took quite sometime and I got a little bit carried away but I was able to port all of my current assignments over into the mui cards and formatted w/ styling!

They each have a picture, description, title and links to their own repositories on github and links to their live deployments on github or heroku!

This is all displaying under the portfolio section of the page and while it could match the palette, style/tone better I feel proud in getting what I could setup.

Now working on Resume Content!